### PR TITLE
Allow module to create Secure Web Proxy with TLS inspection enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "google_network_security_gateway_security_policy_rule" "this" {
   session_matcher         = each.value.session_matcher
   application_matcher     = each.value.application_matcher
   basic_profile           = each.value.basic_profile
-  tls_inspection_enabled  = lookup(var.policy, "tls_inspection_policy", null) != null ? true : false
+  tls_inspection_enabled  = each.value.tls_inspection_enabled
   depends_on = [
     google_network_security_url_lists.this
   ]

--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,7 @@ resource "google_network_security_gateway_security_policy_rule" "this" {
   session_matcher         = each.value.session_matcher
   application_matcher     = each.value.application_matcher
   basic_profile           = each.value.basic_profile
+  tls_inspection_enabled  = lookup(var.policy, "tls_inspection_policy", null) != null ? true : false
   depends_on = [
     google_network_security_url_lists.this
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -82,12 +82,13 @@ variable "policy" {
 
 variable "rules" {
   type = map(object({
-    enabled             = optional(bool, true)
-    description         = optional(string, "SWP rules created by terraform")
-    priority            = number                                                # Lower number corresponds to higher precedence.
-    session_matcher     = optional(string, "inIpRange(source.ip, '0.0.0.0/0')") # By default, open all source ips.
-    application_matcher = optional(string)
-    basic_profile       = optional(string, "ALLOW") # Supports ALLOW or DENY.string
+    enabled                = optional(bool, true)
+    description            = optional(string, "SWP rules created by terraform")
+    priority               = number                                                # Lower number corresponds to higher precedence.
+    session_matcher        = optional(string, "inIpRange(source.ip, '0.0.0.0/0')") # By default, open all source ips.
+    application_matcher    = optional(string)
+    basic_profile          = optional(string, "ALLOW") # Supports ALLOW or DENY.string
+    tls_inspection_enabled = optional(bool, false)
   }))
   description = "Security policy rules configuration."
   default     = null


### PR DESCRIPTION
## Changes
Allow module to create Secure Web Proxy with TLS inspection enabled
- Added `tls_inspection_enabled` to `rules` variable type.
- Pass `tls_inspection_enabled` field in creation of `google_network_security_gateway_security_policy_rule`

## Example use
```
module "secure_web_proxy" {
  source  = "GoogleCloudPlatform/secure-web-proxy/google"
  version = "0.1.0"

  gateway_name     = "simple-swp"
  project_id       = var.project_id
  region           = var.region
  certificate_urls = [google_certificate_manager_certificate.this.id]
  network          = google_compute_network.this.id
  subnetwork       = google_compute_subnetwork.resource_subnet.id

  policy = {
    name        = "simple-proxy-policy"
    description = "Policy for secure web proxy"
  }

  rules = {
    "allow-example1-com" = {
      enabled         = true
      description     = "Allow example1.com host traffic."
      priority        = 100
      session_matcher = "host() == 'example1.com'"
      basic_profile   = "ALLOW"
      tls_inspection_enabled = true
    }
  }
}
```